### PR TITLE
RT133623 Disable XS build check in pureperl mode

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -65,7 +65,7 @@ my %TEST_DEPS = (
     'Storable'   => 0,
     'Test::More' => 0.96,
 );
-my @XS_FILES = qw(Util.xs);
+my @XS_FILES = ($loadable_xs ? qw(Util.xs) : ());
 
 WriteMakefile1(
     META_MERGE => {

--- a/inc/Config/AutoConf/ParamsUtil.pm
+++ b/inc/Config/AutoConf/ParamsUtil.pm
@@ -13,17 +13,12 @@ sub new
     return $self;
 }
 
-#    AX_CHECK_LIB_FLAGS([log4cplus], [stdc++,stdc++ unwind], [log4cplus_initialize();], [
-#    AC_INCLUDES_DEFAULT
-##include <log4cplus/clogger.h>
-#      ], [log4cplus >= 2.0.0], [
-
 sub check_paramsutil_prerequisites
 {
     my $self = shift->_get_instance();
 
-    $self->{config}->{cc}                    or $self->check_prog_cc();
-    $self->check_produce_loadable_xs_build() or die "Can't produce loadable XS module";
+    $self->{config}->{cc} or $self->check_prog_cc();
+    return $self->check_produce_loadable_xs_build();
 }
 
 1;


### PR DESCRIPTION
RT: https://rt.cpan.org/Public/Bug/Display.html?id=133623

I'm not sure how to build the module from the repo, but this fix works
when applied to the latest tarball.

Let me know if there's anything I should do.

Cheers!