### PR TITLE
Skip building XS when PUREPERL_ONLY=1 set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,100 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+
+jobs:
+  dist:
+    name: Make distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Cache ~/perl5
+        uses: actions/cache@v2
+        with:
+          key: ${{ runner.os }}-dist-locallib
+          path: ~/perl5
+      - name: Perl version
+        run: |
+          perl -v
+      - name: Install cpanm
+        run: |
+          curl -L https://cpanmin.us | perl - --sudo App::cpanminus
+      - name: Install local::lib
+        run: |
+          cpanm --local-lib=~/perl5 local::lib && eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+      - name: Install author deps
+        shell: bash
+        run: |
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          cpanm --notest --with-recommends --with-suggests Test::WriteVariants Config::AutoConf Carp inc::latest
+      - name: Make distribution
+        shell: bash
+        run: |
+          eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib)
+          perl Makefile.PL
+          make manifest dist DISTVNAME=dist
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dist
+          path: ./dist.tar.gz
+  test:
+    needs: dist
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+        perl: ['5']
+        pureperl: [ false, true ]
+        include:
+          - { os: 'ubuntu-latest', perl: "5.34" }
+          - { os: 'ubuntu-latest', perl: "5.32" }
+          - { os: 'ubuntu-latest', perl: "5.30" }
+          - { os: 'ubuntu-latest', perl: "5.28" }
+          - { os: 'ubuntu-latest', perl: "5.26" }
+          - { os: 'ubuntu-latest', perl: "5.24" }
+          - { os: 'ubuntu-latest', perl: "5.22" }
+          - { os: 'ubuntu-latest', perl: "5.20" }
+          - { os: 'ubuntu-latest', perl: "5.18" }
+          - { os: 'ubuntu-latest', perl: "5.16" }
+          - { os: 'ubuntu-latest', perl: "5.14" }
+          - { os: 'ubuntu-latest', perl: "5.12" }
+          - { os: 'ubuntu-latest', perl: "5.10" }
+          - { os: 'ubuntu-latest', perl: "5.8"  }
+          - { os: 'ubuntu-latest', perl: "5"   , pureperl: true, force_cc_fail: true }
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }} (${{ format('{0}, {1}', fromJSON('["","pureperl"]')[matrix.pureperl], fromJSON('["","force cc failure"]')[matrix.force_cc_fail]) }})
+
+    steps:
+      - name: Get dist artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+
+      - name: Set up perl
+        uses: shogo82148/actions-setup-perl@v1
+        if: matrix.os != 'windows-latest'
+        with:
+          perl-version: ${{ matrix.perl }}
+      - name: Set up perl (Strawberry)
+        uses: shogo82148/actions-setup-perl@v1
+        if: matrix.os == 'windows-latest'
+        with:
+          distribution: 'strawberry'
+
+      - run: perl -V
+
+      - name: Install Perl deps
+        run: |
+          cpanm --notest --installdeps dist.tar.gz
+
+      - name: Run tests
+        run:
+          cpanm --verbose --test-only
+              ${{ fromJSON('[ "", "--pureperl" ]')[ matrix.pureperl ] }}
+              ${{ fromJSON('[ "", "--build-args=\"CC=false\"" ]')[ matrix.force_cc_fail ] }}
+              dist.tar.gz

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -120,6 +120,7 @@ WriteMakefile1(
     TEST_REQUIRES      => \%TEST_DEPS,
     XS                 => {map { (my $tgt = $_) =~ s/\.xs$/\.c/; $_ => $tgt; } @XS_FILES},
     MAGICXS            => 1,
+    SKIP               => [ $loadable_xs ? () : qw(static dynamic) ],
     depend             => {'$(FIRST_MAKEFILE)' => '$(VERSION_FROM)'},
     test               => {TESTS               => join(' ', 't/pp/*.t', ($loadable_xs ? 't/xs/*.t' : ()), 'xt/*.t')},
     # Otherwise 'cxinc' isn't defined


### PR DESCRIPTION
This change skips the static/dynamic sections of the Makefile when using a
pure-Perl install so that no XS linking is done at all.

Compare the build logs below:

```shell
$ for br in master pureperl-skip-linking; do \
echo "On branch $br"; \
git checkout -q $br ; \
git clean -f; \
( perl Makefile.PL PUREPERL_ONLY=1 && make && make clean)  | grep -Fe $( perl -MConfig -e 'print $Config{cc}' ); \
echo; \
done
```

```
On branch master
Checking for cc... cc
cc -c   -fwrapv -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -O2   -DVERSION=\"1.102\" -DXS_VERSION=\"1.102\" -fPIC "-I$HOME/perl5/perlbrew/perls/perl-5.26.1/lib/5.26.1/x86_64-linux/CORE"   Util.c
cc  -shared -O2 -L/usr/local/lib -fstack-protector-strong  Util.o  -o blib/arch/auto/Params/Util/Util.so  \

On branch pureperl-skip-linking
Checking for cc... cc
```
