### PR TITLE
chore(ci): Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,32 @@ on:
   pull_request:
 
 jobs:
+  perl-version:
+    name: Fetch available perl versions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: shogo82148/actions-setup-perl@v1
+      - id: set-matrix
+        name: Generate matrix for perl versions
+        shell: perl {0}
+        run: |
+          use Actions::Core;
+          use JSON::PP;
+          use version;
+          my $perl_min_version = version->parse("v5.8");
+          my @versions = grep { version->parse("v$_") >= $perl_min_version }
+                         perl_versions(platform => 'linux');
+          my @include = map { +{ os => 'ubuntu-latest', perl => $_ } } @versions;
+          push @include, {
+            os            => 'ubuntu-latest',
+            perl          => '5',
+            pureperl      => JSON::PP::true,
+            force_cc_fail => JSON::PP::true,
+          };
+          set_output(matrix_include => \@include);
+    outputs:
+      matrix_include: ${{ steps.set-matrix.outputs.matrix_include }}
+
   dist:
     name: Make distribution
     runs-on: ubuntu-latest
@@ -44,29 +70,14 @@ jobs:
           name: dist
           path: ./dist.tar.gz
   test:
-    needs: dist
+    needs: [dist, perl-version]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
         perl: ['5']
-        pureperl: [ false, true ]
-        include:
-          - { os: 'ubuntu-latest', perl: "5.34" }
-          - { os: 'ubuntu-latest', perl: "5.32" }
-          - { os: 'ubuntu-latest', perl: "5.30" }
-          - { os: 'ubuntu-latest', perl: "5.28" }
-          - { os: 'ubuntu-latest', perl: "5.26" }
-          - { os: 'ubuntu-latest', perl: "5.24" }
-          - { os: 'ubuntu-latest', perl: "5.22" }
-          - { os: 'ubuntu-latest', perl: "5.20" }
-          - { os: 'ubuntu-latest', perl: "5.18" }
-          - { os: 'ubuntu-latest', perl: "5.16" }
-          - { os: 'ubuntu-latest', perl: "5.14" }
-          - { os: 'ubuntu-latest', perl: "5.12" }
-          - { os: 'ubuntu-latest', perl: "5.10" }
-          - { os: 'ubuntu-latest', perl: "5.8"  }
-          - { os: 'ubuntu-latest', perl: "5"   , pureperl: true, force_cc_fail: true }
+        pureperl: [false, true]
+        include: ${{ fromJSON(needs.perl-version.outputs.matrix_include) }}
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }} (${{ format('{0}, {1}', fromJSON('["","pureperl"]')[matrix.pureperl], fromJSON('["","force cc failure"]')[matrix.force_cc_fail]) }})
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Cache ~/perl5
-        uses: actions/cache@v2
+        uses: actions/cache@v5
         with:
           key: ${{ runner.os }}-dist-locallib
           path: ~/perl5
@@ -39,7 +39,7 @@ jobs:
           perl Makefile.PL
           make manifest dist DISTVNAME=dist
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v6
         with:
           name: dist
           path: ./dist.tar.gz
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Get dist artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v7
         with:
           name: dist
 


### PR DESCRIPTION
The versions of the actions need to be upgraded in order to run on the
latest builds of the GitHub Actions runners.
